### PR TITLE
Remove C functions from the dump generated by FunctionsDumper

### DIFF
--- a/lib/multitenancy_tools/functions_dumper.rb
+++ b/lib/multitenancy_tools/functions_dumper.rb
@@ -2,10 +2,23 @@ module MultitenancyTools
   # {FunctionsDumper} can be used to generate a SQL dump of all functions that
   # are present on a PostgreSQL schema.
   #
+  # Please note that C functions are not included in the dump.
+  #
   # @example
   #   dumper = MultitenancyTools::FunctionsDumper.new('schema name')
   #   dumper.dump_to('path/to/file.sql')
   class FunctionsDumper
+    FUNCTIONS_SQL = <<-SQL.freeze
+      SELECT
+        trim(trailing e' \n' from pg_get_functiondef(f.oid)) || ';'
+        AS definition
+      FROM pg_catalog.pg_proc f
+      JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid)
+      JOIN pg_catalog.pg_language l ON (f.prolang = l.oid)
+      WHERE n.nspname = %s
+      AND l.lanname != 'c';
+    SQL
+
     # @param schema [String] schema name
     # @param connection [ActiveRecord::ConnectionAdapters::PostgreSQLAdapter] connection adapter
     def initialize(schema, connection = ActiveRecord::Base.connection)
@@ -21,18 +34,11 @@ module MultitenancyTools
     # @param file [String] file path
     # @param mode [String] IO open mode
     def dump_to(file, mode: 'w')
-      results = @connection.execute(<<-SQL)
-        SELECT
-          trim(trailing e' \n' from pg_get_functiondef(f.oid)) || ';\n'
-          AS definition
-        FROM pg_catalog.pg_proc f
-        INNER JOIN pg_catalog.pg_namespace n ON (f.pronamespace = n.oid)
-        WHERE n.nspname = #{@schema};
-      SQL
+      results = @connection.execute(format(FUNCTIONS_SQL, @schema))
 
       File.open(file, mode) do |f|
         results.each do |result|
-          f.write result['definition']
+          f.puts result.fetch('definition')
         end
       end
     end

--- a/spec/multitenancy_tools/functions_dumper_spec.rb
+++ b/spec/multitenancy_tools/functions_dumper_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe MultitenancyTools::FunctionsDumper do
               RETURN i + 1;
           END;
       $$ LANGUAGE plpgsql;
+      -- this line creates some hstore functions that are C based
+      CREATE EXTENSION hstore WITH SCHEMA schema1;
     SQL
   end
 
@@ -50,6 +52,10 @@ RSpec.describe MultitenancyTools::FunctionsDumper do
     it 'does not include functions from other schemas' do
       expect(file).to_not match(/schema2/)
       expect(file).to_not match(/function_for_schema2/)
+    end
+
+    it 'does not include C functions' do
+      expect(file).to_not match(/hstore/)
     end
   end
 end


### PR DESCRIPTION
When "CREATE EXTENSION <name>" is executed in the database, some C functions are registered in the catalog. These functions are always created by "CREATE EXTENSION", so there is no need to dump these functions.
