### PR TITLE
WIP: Allow changing dump host and user

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ dumper = MultitenancyTools::SchemaDumper.new('database name', 'schema name')
 dumper.dump_to('path/to/file.sql')
 ```
 
+#### Dumping from a differente host and using a differente username
+```ruby
+options = { host: 'db-on-docker', username: 'non-root-user' }
+dumper = MultitenancyTools::SchemaDumper.new('database name', 'schema name', options)
+dupmer.dump_to('path/to/file.sql')
+```
+
 ### Dumping the content of a table to a SQL file
 
 Like `SchemaDumper`, this tool also requires `pg_dump` to be on the `PATH`:
@@ -47,6 +54,13 @@ Like `SchemaDumper`, this tool also requires `pg_dump` to be on the `PATH`:
 ```ruby
 dumper = MultitenancyTools::TableDumper.new('database name', 'schema name', 'table name')
 dumper.dump_to('path/to/file.sql')
+```
+
+#### Dumping from a differente host and using a differente username
+```ruby
+options = { host: 'db-on-docker', username: 'non-root-user' }
+dumper = MultitenancyTools::TableDumper.new('database name', 'schema name', 'table_name', options)
+dupmer.dump_to('path/to/file.sql')
 ```
 
 ### Creating a new PostgreSQL schema using a SQL file as template

--- a/lib/multitenancy_tools/schema_dumper.rb
+++ b/lib/multitenancy_tools/schema_dumper.rb
@@ -21,9 +21,11 @@ module MultitenancyTools
   class SchemaDumper
     # @param database [String] database name
     # @param schema [String] schema name
-    def initialize(database, schema)
+    def initialize(database, schema, options = {})
       @database = database
       @schema = schema
+      @host = options.fetch(:host, '')
+      @username = options.fetch(:username, '')
     end
 
     # Generates a dump an writes it into a file. Please see {IO.new} for open
@@ -41,7 +43,9 @@ module MultitenancyTools
         '--no-privileges',
         '--no-tablespaces',
         '--no-owner',
-        '--dbname', @database
+        '--dbname', @database,
+        '--host', @host,
+        '--username', @username
       )
 
       fail(PgDumpError, stderr) unless status.success?

--- a/lib/multitenancy_tools/table_dumper.rb
+++ b/lib/multitenancy_tools/table_dumper.rb
@@ -20,10 +20,12 @@ module MultitenancyTools
     # @param database [String] database name
     # @param schema [String] schema name
     # @param table [String] table name
-    def initialize(database, schema, table)
+    def initialize(database, schema, table, options = {})
       @database = database
       @schema = schema
       @table = table
+      @host = options.fetch(:host, '')
+      @username = options.fetch(:username, '')
     end
 
     # Generates a dump an writes it into a file. Please see {IO.new} for open
@@ -42,7 +44,9 @@ module MultitenancyTools
         '--no-tablespaces',
         '--no-owner',
         '--inserts',
-        '--dbname', @database
+        '--dbname', @database,
+        '--host', @host,
+        '--username', @username
       )
 
       fail(PgDumpError, stderr) unless status.success?

--- a/lib/multitenancy_tools/version.rb
+++ b/lib/multitenancy_tools/version.rb
@@ -1,3 +1,3 @@
 module MultitenancyTools
-  VERSION = '0.1.12'
+  VERSION = '0.1.13'
 end

--- a/lib/multitenancy_tools/version.rb
+++ b/lib/multitenancy_tools/version.rb
@@ -1,3 +1,3 @@
 module MultitenancyTools
-  VERSION = '0.1.13'
+  VERSION = '0.1.12'
 end

--- a/multitenancy_tools.gemspec
+++ b/multitenancy_tools.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '~> 4.2.0'
   spec.add_dependency 'activesupport', '~> 4.2.0'
-  spec.add_dependency 'pg'
+  spec.add_dependency 'pg', '< 1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/multitenancy_tools/schema_dumper_spec.rb
+++ b/spec/multitenancy_tools/schema_dumper_spec.rb
@@ -107,5 +107,23 @@ RSpec.describe MultitenancyTools::SchemaDumper do
         subject.dump_to('dump.sql', mode: 'a')
       end
     end
+
+    context 'changing server host' do
+      it 'connects to a different host when host argument is provided' do
+        file = Tempfile.new('lalala')
+        expect do
+          described_class.new(Db.name, 'schema1', { host: 'another_host' }).dump_to(file)
+        end.to raise_error MultitenancyTools::PgDumpError, /could not translate host name/
+      end
+    end
+
+    context 'changing database username' do
+      it 'connects using a different user when username is provided' do
+        file = Tempfile.new('lalala')
+        expect do
+          described_class.new(Db.name, 'schema1', { username: 'richard' }).dump_to(file)
+        end.to raise_error MultitenancyTools::PgDumpError, /authentication failed for user/
+      end
+    end
   end
 end

--- a/spec/multitenancy_tools/table_dumper_spec.rb
+++ b/spec/multitenancy_tools/table_dumper_spec.rb
@@ -105,5 +105,23 @@ RSpec.describe MultitenancyTools::TableDumper do
         subject.dump_to('dump.sql', mode: 'a')
       end
     end
+
+    context 'changing server host' do
+      it 'connects to a different host when host argument is provided' do
+        file = Tempfile.new('lalala')
+        expect do
+          described_class.new(Db.name, 'schema1', 'posts', { host: 'another_host' }).dump_to(file)
+        end.to raise_error MultitenancyTools::PgDumpError, /could not translate host name/
+      end
+    end
+
+    context 'changing database username' do
+      it 'connects using a different user when username is provided' do
+        file = Tempfile.new('lalala')
+        expect do
+          described_class.new(Db.name, 'schema1', 'posts', { username: 'richard' }).dump_to(file)
+        end.to raise_error MultitenancyTools::PgDumpError, /authentication failed for user/
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'multitenancy_tools'
 


### PR DESCRIPTION
Allow `SchemaDumper` and `TableDumper` to dump on a different database than localhost and using a different username. This is particularlly useful when running on Docker since the database no longer runs on localhost.

Also removing CodeClimate from `spec_helper` since it has been deprecated :)